### PR TITLE
Added Interactive Brokers Tiered pricing

### DIFF
--- a/data/brokers.json
+++ b/data/brokers.json
@@ -168,5 +168,23 @@
         "costOverview": "https://www.interactivebrokers.ie/en/index.php?f=48059",
         "website": "https://www.interactivebrokers.ie/en/home.php",
         "affiliateLink": "https://ibkr.com/referral/nic106"
+    },
+    {
+        "name": "Interactive Brokers Tiered",
+        "logo": "interactive-brokers.png",
+        "product": "Tiered Pricing",
+        "etfTransactionFee": {
+            "percentage": 0.0558,
+            "minimum": 1.89,
+            "maximum": 29.64
+        },
+        "mutualFundTransactionFee": {
+            "percentage": 0.0558,
+            "minimum": 1.89,
+            "maximum": 29.64
+        },
+        "costOverview": "https://www.interactivebrokers.ie/en/index.php?f=48059",
+        "website": "https://www.interactivebrokers.ie/en/home.php",
+        "affiliateLink": "https://ibkr.com/referral/nic106"
     }
 ]

--- a/data/brokers.json
+++ b/data/brokers.json
@@ -176,12 +176,12 @@
         "etfTransactionFee": {
             "percentage": 0.0558,
             "minimum": 1.89,
-            "maximum": 29.64
+            "maximum": 77.04
         },
         "mutualFundTransactionFee": {
-            "percentage": 0.0558,
-            "minimum": 1.89,
-            "maximum": 29.64
+            "percentage": 0.1,
+            "minimum": 3.65,
+            "maximum": 74.10
         },
         "costOverview": "https://www.interactivebrokers.ie/en/index.php?f=48059",
         "website": "https://www.interactivebrokers.ie/en/home.php",

--- a/data/portfolios.json
+++ b/data/portfolios.json
@@ -50,6 +50,7 @@
             "DEGIRO",
             "Saxo Bank",
             "Interactive Brokers",
+            "Interactive Brokers Tiered",
             "Lynx"
         ]
     },
@@ -63,6 +64,7 @@
         "brokers": [
             "DEGIRO",
             "Interactive Brokers",
+            "Interactive Brokers Tiered",
             "Lynx",
             "Saxo Bank"
         ]
@@ -107,6 +109,7 @@
         "brokers": [
             "Saxo Bank",
             "Interactive Brokers",
+            "Interactive Brokers Tiered",
             "Lynx"
         ]
     },
@@ -128,6 +131,7 @@
         "brokers": [
             "Saxo Bank",
             "Interactive Brokers",
+            "Interactive Brokers Tiered",
             "Lynx"
         ]
     },
@@ -145,6 +149,7 @@
         "brokers": [
             "DEGIRO",
             "Interactive Brokers",
+            "Interactive Brokers Tiered",
             "Lynx",
             "Saxo Bank"
         ]

--- a/wijzigingen.html
+++ b/wijzigingen.html
@@ -30,6 +30,18 @@
             <h1 class="h2">Wijzigingen</h1>
 
             <article>
+                <h2 class="h4 mb-0">Kostenschema Interactive Brokers - Tiered Pricing</h2>
+
+                <p class="text-muted">24 januari 2021</p>
+
+                <p>Het alternatieve kostenschema voor Interactive Brokers (Tiered Pricing) is nu ook als aanbieder toegevoegd. 
+                    De kostenberekeningen gaan uit van verhandeling op de Duitse Xetra beurs, daarnaast vallen de werkelijke 
+                    kosten wat lager uit bij stortingen > 50.000. Er is dus wat afwijking mogelijk met de werkelijke kosten, 
+                    maar het biedt een aardige indicatie van de kosten in de meeste gevallen. Veelal komt dit ook in 
+                    werkelijkheid gunstiger uit dan een Fixed Pricing optie via Interactive Brokers.</p>
+            </article>
+
+            <article>
                 <h2 class="h4 mb-0">Beleggingsfondsen bij Interactive Brokers</h2>
 
                 <p class="text-muted">11 januari 2021</p>


### PR DESCRIPTION
Het Tiered Pricing model van Interactive Brokers komt in de meeste gevallen goedkoper uit dan het gebruikte Fixed Pricing model. Hoewel niet 100% accuraat, geeft deze nieuwe broker configuratie een aardige indicatie van het kostenverschil.