### PR TITLE
Fix CARIW + EMIM portfolio

### DIFF
--- a/data/portfolios.json
+++ b/data/portfolios.json
@@ -103,7 +103,7 @@
             },
             {
                 "allocation": 16,
-                "fund": "CARIEM"
+                "fund": "EMIM"
             }
         ],
         "brokers": [


### PR DESCRIPTION
I made a mistake on #42. For the AVIAW + EMIM portfolio I erroneously replaced EMIM with CARIEM. This change reverts that.

Fixes #43