### PR TITLE
Update market data

### DIFF
--- a/data/indices.json
+++ b/data/indices.json
@@ -7,7 +7,7 @@
             "mid",
             "small"
         ],
-        "marketCapitalization": 72144376.72,
+        "marketCapitalization": 75780070.59,
         "percentageOfTotalMarketCapitalization": 100,
         "factsheet": "https://www.msci.com/documents/10199/4211cc4b-453d-4b0a-a6a7-51d36472a703"
     },
@@ -18,9 +18,9 @@
             "large",
             "mid"
         ],
-        "marketCapitalization": 52988851.48,
-        "percentageOfTotalMarketCapitalization": 73.44834606535638,
-        "factsheet": "https://www.msci.com/documents/10199/149ed7bc-316e-4b4c-8ea4-43fcb5bd6523"
+        "marketCapitalization": 60208310.38,
+        "percentageOfTotalMarketCapitalization": 79.45137806185303,
+        "factsheet": "https://www.msci.com/documents/10199/4db922ce-68d2-446d-2f9e-4ed408a9db29"
     },
     {
         "name": "MSCI World Small Cap Index",
@@ -28,8 +28,8 @@
         "sizes": [
             "small"
         ],
-        "marketCapitalization": 6599811.99,
-        "percentageOfTotalMarketCapitalization": 9.148061553867977,
+        "marketCapitalization": 7335299.65,
+        "percentageOfTotalMarketCapitalization": 9.679721321040802,
         "factsheet": "https://www.msci.com/documents/10199/a67b0d43-0289-4bce-8499-0c102eaa8399"
     },
     {
@@ -39,8 +39,8 @@
             "large",
             "mid"
         ],
-        "marketCapitalization": 6761002.48,
-        "percentageOfTotalMarketCapitalization": 9.371489210087947,
+        "marketCapitalization": 7066819.21,
+        "percentageOfTotalMarketCapitalization": 9.32543233990144,
         "factsheet": "https://www.msci.com/documents/10199/c0db0a48-01f2-4ba9-ad01-226fd5678111"
     },
     {
@@ -51,8 +51,8 @@
             "mid",
             "small"
         ],
-        "marketCapitalization": 7888254.79,
-        "percentageOfTotalMarketCapitalization": 10.933984253014142,
+        "marketCapitalization": 8236460.57,
+        "percentageOfTotalMarketCapitalization": 10.86890063030225,
         "factsheet": "https://www.msci.com/documents/10199/97e25eb7-9bd0-4204-bea9-077095acf1d3"
     },
     {
@@ -62,8 +62,8 @@
             "large",
             "mid"
         ],
-        "marketCapitalization": 64954623,
-        "percentageOfTotalMarketCapitalization": 90.03421465833131,
+        "marketCapitalization": 67837110,
+        "percentageOfTotalMarketCapitalization": 89.51840434014036,
         "factsheet": "https://research.ftserussell.com/Analytics/Factsheets/Home/DownloadSingleIssue?issueName=AWORLDS&IsManual=false"
     },
     {
@@ -73,8 +73,8 @@
             "large",
             "mid"
         ],
-        "marketCapitalization": 58582562,
-        "percentageOfTotalMarketCapitalization": 81.20184089657488,
+        "marketCapitalization": 61205333,
+        "percentageOfTotalMarketCapitalization": 80.76705725327828,
         "factsheet": "https://research.ftserussell.com/Analytics/FactSheets/Home/DownloadSingleIssue?issueName=AWD&IsManual=False"
     },
     {
@@ -84,8 +84,8 @@
             "large",
             "mid"
         ],
-        "marketCapitalization": 52988851.48,
-        "percentageOfTotalMarketCapitalization": 73.44834606535638,
+        "marketCapitalization": 60208310.38,
+        "percentageOfTotalMarketCapitalization": 79.45137806185303,
         "factsheet": ""
     },
     {
@@ -95,8 +95,8 @@
             "large",
             "mid"
         ],
-        "marketCapitalization": 6761002.48,
-        "percentageOfTotalMarketCapitalization": 9.371489210087947,
+        "marketCapitalization": 7066819.21,
+        "percentageOfTotalMarketCapitalization": 9.32543233990144,
         "factsheet": ""
     },
     {
@@ -105,8 +105,8 @@
         "sizes": [
             "small"
         ],
-        "marketCapitalization": 6599811.99,
-        "percentageOfTotalMarketCapitalization": 9.148061553867977,
+        "marketCapitalization": 7335299.65,
+        "percentageOfTotalMarketCapitalization": 9.679721321040802,
         "factsheet": ""
     },
     {
@@ -117,8 +117,8 @@
             "mid",
             "small"
         ],
-        "marketCapitalization": 62524362.48,
-        "percentageOfTotalMarketCapitalization": 86.66560766428644,
+        "marketCapitalization": 70327381.98,
+        "percentageOfTotalMarketCapitalization": 92.80458758147483,
         "factsheet": ""
     }
 ]

--- a/data/portfolios.json
+++ b/data/portfolios.json
@@ -2,11 +2,11 @@
     {
         "portfolio": [
             {
-                "allocation": 89,
+                "allocation": 90,
                 "fund": "NT World"
             },
             {
-                "allocation": 11,
+                "allocation": 10,
                 "fund": "NT EM"
             }
         ],
@@ -19,11 +19,11 @@
     {
         "portfolio": [
             {
-                "allocation": 81,
+                "allocation": 82,
                 "fund": "NT World"
             },
             {
-                "allocation": 10,
+                "allocation": 9,
                 "fund": "NT EM"
             },
             {
@@ -83,11 +83,11 @@
     {
         "portfolio": [
             {
-                "allocation": 89,
+                "allocation": 91,
                 "fund": "CARIW"
             },
             {
-                "allocation": 11,
+                "allocation": 9,
                 "fund": "CARIEM"
             }
         ],
@@ -98,11 +98,11 @@
     {
         "portfolio": [
             {
-                "allocation": 84,
+                "allocation": 86,
                 "fund": "CARIW"
             },
             {
-                "allocation": 16,
+                "allocation": 14,
                 "fund": "EMIM"
             }
         ],
@@ -116,7 +116,7 @@
     {
         "portfolio": [
             {
-                "allocation": 75,
+                "allocation": 76,
                 "fund": "CARIW"
             },
             {
@@ -124,7 +124,7 @@
                 "fund": "EMIM"
             },
             {
-                "allocation": 12,
+                "allocation": 11,
                 "fund": "IUSN"
             }
         ],

--- a/data/portfolios.json
+++ b/data/portfolios.json
@@ -92,7 +92,10 @@
             }
         ],
         "brokers": [
-            "Saxo Bank"
+            "Saxo Bank",
+            "Interactive Brokers",
+            "Lynx",
+            "Easybroker"
         ]
     },
     {

--- a/src/Import/IndexImporter.php
+++ b/src/Import/IndexImporter.php
@@ -15,7 +15,7 @@ final class IndexImporter implements DataImporter
 
     private const FACTSHEETS = [
         'MSCI ACWI IMI Index' => 'https://www.msci.com/documents/10199/4211cc4b-453d-4b0a-a6a7-51d36472a703',
-        'MSCI World Index' => 'https://www.msci.com/documents/10199/149ed7bc-316e-4b4c-8ea4-43fcb5bd6523',
+        'MSCI World Index' => 'https://www.msci.com/documents/10199/4db922ce-68d2-446d-2f9e-4ed408a9db29',
         'MSCI World Small Cap Index' => 'https://www.msci.com/documents/10199/a67b0d43-0289-4bce-8499-0c102eaa8399',
         'MSCI Emerging Markets Index' => 'https://www.msci.com/documents/10199/c0db0a48-01f2-4ba9-ad01-226fd5678111',
         'MSCI Emerging Markets IMI Index' => 'https://www.msci.com/documents/10199/97e25eb7-9bd0-4204-bea9-077095acf1d3',

--- a/src/Import/MsciFactsheetParser.php
+++ b/src/Import/MsciFactsheetParser.php
@@ -44,7 +44,7 @@ final class MsciFactsheetParser implements IndexFactsheetParser
         $text = $this->getText($document);
 
         if (preg_match(
-            '/representation across \d+ Developed ?Markets ?\(DM\) and \d+ Emerging ?Markets ?\(EM\) countries/i',
+            '/representation across \d+ Developed ?Markets ?\(DM\) and.\d+ Emerging ?Markets ?\(EM\) countries/i',
             $text
         )) {
             return 'all-world';


### PR DESCRIPTION
- De MSCI World Index sheet linkte naar een oude URL waardoor vrijwel alle marktkapitalisatie berekeningen niet actueel waren
- Update van de market cap data en rebalance gedraaid op basis van de nieuwste sheets
- CARIEM is (weer?) beschikbaar bij IB brokers