### PR TITLE
Update ING broker pricing

### DIFF
--- a/data/brokers.json
+++ b/data/brokers.json
@@ -8,7 +8,10 @@
             "tiers": [
                 {"upperLimit": 100000, "percentage": 0.06},
                 {"upperLimit": 500000, "percentage": 0.03},
-                {"upperLimit": null, "percentage": 0.015}
+                {"upperLimit": 2500000, "percentage": 0.02},
+                {"upperLimit": 5000000, "percentage": 0.015},
+                {"upperLimit": 10000000, "percentage": 0.0125},
+                {"upperLimit": null, "percentage": 0.01},
             ]
         },
         "serviceFeeCalculation": "averageEndOfMonth",


### PR DESCRIPTION
ING updated it's pricing structure on 1 juli 2024.
See source: https://www.ing.nl/particulier/beleggen/beleggen-bij-ing/tarieven-zelf-op-de-beurs (unchanged from current listed source on indexfondsenvergelijken.nl)
